### PR TITLE
[codex] Fix Deezer crypto import mismatch

### DIFF
--- a/musicdl/modules/utils/deezerutils.py
+++ b/musicdl/modules/utils/deezerutils.py
@@ -11,7 +11,7 @@ import base64
 import hashlib
 import binascii
 import functools
-from Cryptodome.Cipher import AES, Blowfish
+from Crypto.Cipher import AES, Blowfish
 
 
 '''DeezerMusicClientUtils'''


### PR DESCRIPTION
## Summary
- switch Deezer's AES/Blowfish import from `Cryptodome` to `Crypto`
- align the Deezer utility with the package's declared `pycryptodome` dependency and the rest of the codebase
- fix the startup crash reported in issue #56 when `musicdl` imports all source modules eagerly

## Root Cause
`requirements.txt` declares `pycryptodome`, which exposes the `Crypto.*` namespace. `deezerutils.py` imported `Cryptodome.*` instead, so the CLI crashed during module import before it could honor the user-selected music sources.

Fixes #56.

## Validation
- `uvx musicdl --version` reproduced the `ModuleNotFoundError: No module named 'Cryptodome'` failure before the patch
- `uvx --from /Users/yifan/tmp/tmp/repo musicdl --version` succeeds after the patch
