### PR TITLE
Fix: Handle None lyrics in AppleMusicClient to prevent playlist parse failure

### DIFF
--- a/musicdl/modules/sources/apple.py
+++ b/musicdl/modules/sources/apple.py
@@ -116,7 +116,7 @@ class AppleMusicClient(BaseMusicClient):
             download_url_status: dict = self.audio_link_tester.test(url=download_item.stream_info.audio_track.stream_url, request_overrides=request_overrides, renew_session=True)
             song_info = SongInfo(
                 raw_data={'search': search_result, 'download': download_result, 'lyric': {}}, source=self.source, song_name=legalizestring(safeextractfromdict(search_result, ['attributes', 'name'], None)), singers=legalizestring(safeextractfromdict(search_result, ['attributes', 'artistName'], None)), album=legalizestring(safeextractfromdict(search_result, ['attributes', 'albumName'], None)), ext=download_item.stream_info.file_format.value, 
-                file_size_bytes='HLS', file_size='HLS', identifier=song_id, duration_s=duration_in_secs, duration=SongInfoUtils.seconds2hms(duration_in_secs), lyric=cleanlrc(str(download_item.lyrics.synced) or ''), cover_url=safeextractfromdict(search_result, ['attributes', 'artwork', 'url'], None), download_url=download_item, download_url_status=download_url_status,
+                file_size_bytes='HLS', file_size='HLS', identifier=song_id, duration_s=duration_in_secs, duration=SongInfoUtils.seconds2hms(duration_in_secs), lyric=cleanlrc(str(download_item.lyrics.synced) if download_item.lyrics is not None else ''), cover_url=safeextractfromdict(search_result, ['attributes', 'artwork', 'url'], None), download_url=download_item, download_url_status=download_url_status,
             )
             if song_info.cover_url and song_info.cover_url.startswith('http'): song_info.cover_url = song_info.cover_url.format(w=600, h=600, f='jpg')
         # return

--- a/musicdl/modules/sources/apple.py
+++ b/musicdl/modules/sources/apple.py
@@ -116,7 +116,7 @@ class AppleMusicClient(BaseMusicClient):
             download_url_status: dict = self.audio_link_tester.test(url=download_item.stream_info.audio_track.stream_url, request_overrides=request_overrides, renew_session=True)
             song_info = SongInfo(
                 raw_data={'search': search_result, 'download': download_result, 'lyric': {}}, source=self.source, song_name=legalizestring(safeextractfromdict(search_result, ['attributes', 'name'], None)), singers=legalizestring(safeextractfromdict(search_result, ['attributes', 'artistName'], None)), album=legalizestring(safeextractfromdict(search_result, ['attributes', 'albumName'], None)), ext=download_item.stream_info.file_format.value, 
-                file_size_bytes='HLS', file_size='HLS', identifier=song_id, duration_s=duration_in_secs, duration=SongInfoUtils.seconds2hms(duration_in_secs), lyric=cleanlrc(str(download_item.lyrics.synced) if download_item.lyrics is not None else ''), cover_url=safeextractfromdict(search_result, ['attributes', 'artwork', 'url'], None), download_url=download_item, download_url_status=download_url_status,
+                file_size_bytes='HLS', file_size='HLS', identifier=song_id, duration_s=duration_in_secs, duration=SongInfoUtils.seconds2hms(duration_in_secs), lyric=cleanlrc(str(download_item.lyrics.synced) or '') if download_item.lyrics else '', cover_url=safeextractfromdict(search_result, ['attributes', 'artwork', 'url'], None), download_url=download_item, download_url_status=download_url_status,
             )
             if song_info.cover_url and song_info.cover_url.startswith('http'): song_info.cover_url = song_info.cover_url.format(w=600, h=600, f='jpg')
         # return


### PR DESCRIPTION
## Fix

Fixes #99

### 问题 / Problem

当 Apple Music 歌曲没有歌词时（如纯音乐曲目），`getlyrics()` 返回 `None`，导致 `download_item.lyrics` 为 `None`，访问 `.synced` 抛出 `AttributeError`：

```
AttributeError: 'NoneType' object has no attribute 'synced'
```

该异常被 `parseplaylist` 中的 `with suppress(Exception)` 吞掉，导致每首歌都静默失败，最终整个歌单返回 0 首。

### 修复 / Fix

`musicdl/modules/sources/apple.py` 第 119 行，对 `download_item.lyrics` 增加 None 检查：

```python
# 修复前 / Before
lyric=cleanlrc(str(download_item.lyrics.synced) or ''),

# 修复后 / After
lyric=cleanlrc(str(download_item.lyrics.synced) if download_item.lyrics is not None else ''),
```

纯音乐曲目将以空歌词正常下载，不再崩溃。

### 复现 / Reproduce

```python
from musicdl import musicdl

init_cfg = {'AppleMusicClient': {'default_parse_cookies': {'media-user-token': '<your-token>'}}}
mc = musicdl.MusicClient(music_sources=['AppleMusicClient'], init_music_clients_cfg=init_cfg)
songs = mc.parseplaylist('https://music.apple.com/cn/playlist/cello/pl.u-KVXBkAPIzEpA5P')
print(len(songs))  # 修复前: 0, 修复后: 正常数量
```

### 环境 / Environment

- musicdl: 2.13.6
- macOS arm64, Python 3.11