### PR TITLE
fix(audiobooks): bind search_type before use in ximalaya/qingting _search

### DIFF
--- a/musicdl/modules/audiobooks/qingting.py
+++ b/musicdl/modules/audiobooks/qingting.py
@@ -147,13 +147,13 @@ class QingtingMusicClient(BaseMusicClient):
     def _search(self, keyword: str = '', search_url: str = '', request_overrides: dict = None, song_infos: list = [], progress: Progress = None):
         # init
         request_overrides, page_no = request_overrides or {}, int(float(parse_qs(urlparse(url=str(search_url)).query, keep_blank_values=True).get('page')[0]))
+        search_type = parse_qs(urlparse(search_url).query, keep_blank_values=True).get('include')[0]
         task_id = progress.add_task(f"{self.source}.{search_type}._search >>> Start to process search result on page {page_no}", total=None, completed=0)
         # successful
         try:
             # --search results
             (resp := self.get(search_url, **request_overrides)).raise_for_status()
             # --parse based on search type
-            search_type = parse_qs(urlparse(search_url).query, keep_blank_values=True).get('include')[0]
             parsers = {'channel_ondemand': self._parsebyalbum, 'program_ondemand': self._parsebytrack}
             parsers[search_type](resp2json(resp), song_infos=song_infos, request_overrides=request_overrides, progress=progress)
             # --update progress

--- a/musicdl/modules/audiobooks/ximalaya.py
+++ b/musicdl/modules/audiobooks/ximalaya.py
@@ -173,13 +173,13 @@ class XimalayaMusicClient(BaseMusicClient):
     def _search(self, keyword: str = '', search_url: str = '', request_overrides: dict = None, song_infos: list = [], progress: Progress = None):
         # init
         request_overrides, page_no = request_overrides or {}, int(float(parse_qs(urlparse(url=str(search_url)).query, keep_blank_values=True).get('page')[0]))
+        search_type = parse_qs(urlparse(search_url).query, keep_blank_values=True).get('core')[0]
         task_id = progress.add_task(f"{self.source}.{search_type}._search >>> Start to process search result on page {page_no}", total=None, completed=0)
         # successful
         try:
             # --search results
             (resp := self.get(search_url, **request_overrides)).raise_for_status()
             # --parse based on search type
-            search_type = parse_qs(urlparse(search_url).query, keep_blank_values=True).get('core')[0]
             parsers = {'album': self._parsebyalbum, 'track': self._parsebytrack}
             parsers[search_type](resp2json(resp), song_infos=song_infos, request_overrides=request_overrides, progress=progress)
             # --update progress


### PR DESCRIPTION
Fixes #102

## Problem

`XimalayaMusicClient` and `QingtingMusicClient` fail on **every** `search()` call, before any network request happens:

```
Error: cannot access local variable 'search_type' where it is not associated with a value
```

Both `_search()` methods reference `search_type` in the `progress.add_task(...)` f-string, but only assign it later inside the `try` block. Since the name is assigned somewhere in the function, Python treats it as local, so the earlier read raises `UnboundLocalError`. The `except` handler also formats `search_type`, so the original error is masked and surfaces as a generic search failure.

## Fix

Hoist the existing assignment above `add_task`, and remove the now-duplicate line inside `try` (identical expression, so no behaviour change beyond making it reachable).

Net `+1 / -1` per file:

```diff
         request_overrides, page_no = request_overrides or {}, int(float(parse_qs(...).get('page')[0]))
+        search_type = parse_qs(urlparse(search_url).query, keep_blank_values=True).get('core')[0]
         task_id = progress.add_task(f"{self.source}.{search_type}._search >>> ...")
         # successful
         try:
             (resp := self.get(search_url, **request_overrides)).raise_for_status()
             # --parse based on search type
-            search_type = parse_qs(urlparse(search_url).query, keep_blank_values=True).get('core')[0]
             parsers = {'album': self._parsebyalbum, 'track': self._parsebytrack}
```

`qingting.py` is the same change with `'include'` instead of `'core'`.

This matches how the other audiobook clients already do it — `lrts.py`, `lizhi.py` and `itunes.py` all bind `search_type` on the `# init` line.

## Verification

Before — both return empty:

```
XimalayaMusicClient: 0   (UnboundLocalError)
QingtingMusicClient: 0   (UnboundLocalError)
```

After, on the same machine, **no cookies configured for either client**:

```
XimalayaMusicClient (allowed_search_types=['track'])   1 result, 2.8s
  '明朝那些事儿 第13集' | 王更新 | 00:24:28
  https://audiopay.cos.tx.xmcdn.com/download/1.0.0/storages/...

QingtingMusicClient                                    6 albums, 64s
  '三国演义' | 社会万象   (100 episodes)
  '三国演义' | 龙歌少儿有声世界
```

The Ximalaya `download_url` was checked end to end: `HTTP 206`, `Content-Type: audio/mpeg`, body is a real MP3 (`ID3 v2.4`, MPEG layer III, 64 kbps, 44.1 kHz) — so the link plays and supports range requests.

Scope note: this PR only fixes the `UnboundLocalError`. The separate `allowed_search_types=['album']` problem described at the end of #102 is **not** addressed here.
